### PR TITLE
fix: apply README review findings

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -1,8 +1,10 @@
 ### Hi there 👋
 
+I build Java tools, web scrapers, and Kindle dictionaries — with occasional detours into iOS and smart contracts.
+
 #### Personal knowledge base: [`notes.andstuff.dev`](https://notes.andstuff.dev)
 
-#### Top projects
+#### Featured projects
 
 - {{repo 'jmxsh'}}
 - {{repo 'scrapy-seleniumbase-cdp'}}
@@ -23,7 +25,7 @@
   {{#filterout pullRequests 'repo.owner.login' (array 'panticne' 'gs-2019' 'SoftEng-HEIGVD' 'Quartz-Core')}}
   {{#list this sortBy='prCount' direction='desc'}}
   <tr>
-    <td><a href="{{url}}">{{repo.nameWithOwner}}</a></td>
+    <td><a href="{{repo.url}}">{{repo.nameWithOwner}}</a></td>
     <td align="right">{{#each prs}}<a href="{{url}}" title="{{title}}">#{{number}}</a> {{/each}}</td>
   </tr>
   {{/list}}
@@ -34,14 +36,14 @@
 
 <table>
   <tr>
-    <th align="left"><img width="700" height="1">Description</th>
+    <th align="left"><img width="700" height="1">Repository</th>
     <th align="right"><img width="100" height="1"><img src="assets/stargazers.svg"></th>
     <th align="right"><img width="100" height="1"><img src="assets/forks.svg"></th>
     <th align="right"><img width="100" height="1"><img src="assets/issues.svg"></th>
   </tr>
   {{#list repositories sortBy='stargazerCount' direction='desc' top=3}}
   <tr>
-    <td><a href="{{url}}">{{description}}</a></td>
+    <td><a href="{{url}}"><strong>{{name}}</strong></a> — {{description}}</td>
     <td align="right">{{stargazerCount}}</td>
     <td align="right">{{forkCount}}</td>
     <td align="right">{{issues.totalCount}}</td>
@@ -53,14 +55,14 @@
 
 <table>
   <tr>
-    <th align="left"><img width="700" height="1">Description</th>
+    <th align="left"><img width="700" height="1">Gist</th>
     <th align="right"><img width="100" height="1"><img src="assets/stargazers.svg"></th>
     <th align="right"><img width="100" height="1"><img src="assets/forks.svg"></th>
     <th align="right"><img width="100" height="1"><img src="assets/comments.svg"></th>
   </tr>
   {{#list gists sortBy='stargazerCount' direction='desc' top=3}}
   <tr>
-    <td><a href="{{url}}">{{description}}</a></td>
+    <td><a href="{{url}}"><strong>{{files.[0].name}}</strong></a> — {{description}}</td>
     <td align="right">{{stargazerCount}}</td>
     <td align="right">{{forks.totalCount}}</td>
     <td align="right">{{comments.totalCount}}</td>
@@ -110,6 +112,9 @@
 - {{repo 'pagerduty'}}
 - {{repo 'h2-recover'}}
 
+<details>
+<summary>Experiments & more</summary>
+
 #### Code examples
 
 - {{srht owner='nyg' name='example-java-jca' description='Some code example with the Java Cryptography Architecture API, and an attempt at writing a pure-JCA (i.e. Provider-indenpendent) ECDSA and EdDSA signature verification class.'}}
@@ -138,6 +143,8 @@
 - {{gist 'enlarge_image.php'}}
 - {{gist 'fk_generate_delete.sql'}}
 - {{gist 'fk_delete_recursive.sql'}}
+
+</details>
 
 ### Statistics
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,149 @@
+# README Review
+
+> Two independent AI reviews — **Claude Sonnet 4.6** and **GPT-5.4** — were run in parallel on the
+> rendered README and the `src/graphql/` source. Their findings are synthesised below.
+> ✦ = both models raised this independently.
+>
+> Points 1–8 from the original review were addressed in this PR (broken Contributions links,
+> empty PR tooltips, misleading repo descriptions, missing intro, section rename, noise sections
+> collapsed, name-first tables). Open findings follow.
+
+---
+
+## Part 1 — README (self-promotion quality)
+
+**1. No sense of current focus or professional context** *(Sonnet)*
+
+A visitor cannot tell whether this is a student, a professional engineer, or a hobbyist;
+whether the person is open to work; or what they are actively building right now.  
+Fix: one line under the intro is enough — *"Currently working on X; interested in Y."*
+
+**2. iOS/Swift gists are partially duplicated** *(Sonnet)*
+
+`iOSCreatePDF.swift` (75 ★) appears in both the "Most starred gists" table and the "iOS & Swift"
+section. The section then lists 8 gists, most with 0–4 stars and no context on why they matter.  
+Fix: trim the section to 2–3 notable items and let the star table do the rest.
+
+---
+
+## Part 2 — Technical (Apollo + GraphQL)
+
+### Bugs
+
+**3. `fetchAll()` re-fetches page 1 on every call ✦**
+
+`watchQuery()` fires the initial request immediately. `fetchAll()` then starts with
+`cursor = null` and calls `fetchMore({ variables: { cursor: null } })` — the exact same
+variables as the initial request — before checking `hasNextPage`. For any collection with
+fewer than 100 items, page 1 is fetched twice.
+
+Fix:
+
+```js
+this.fetchAll = async () => {
+   let { data } = await observableQuery.result()
+   let pageInfo = extractField(data).pageInfo
+   while (pageInfo.hasNextPage) {
+      ;({ data } = await observableQuery.fetchMore({ variables: { cursor: pageInfo.endCursor } }))
+      pageInfo = extractField(data).pageInfo
+   }
+}
+```
+
+**4. `prCount` can silently drift from `prs.length`, breaking sort order ✦**
+
+`prCount` is incremented manually alongside `prs.push()`. If `prs` is ever filtered later,
+`sortBy='prCount'` in the template silently produces wrong ordering.  
+Fix: remove `prCount` and sort by `prs.length`, or derive the count at sort time.
+
+---
+
+### Design
+
+**5. Apollo Client is the wrong tool for a one-shot CLI ✦**
+
+Apollo exists for reactive, long-lived UI applications: normalized cache, subscriptions,
+re-rendering, type policies. For a script that runs once and exits, you pay the full
+abstraction cost (relayStylePagination merge functions, watchQuery lifecycle, readFragment)
+while using almost none of its value.
+
+The two-phase approach — populate cache via `watchQuery`/`fetchMore`, then extract via
+`readQuery`/`readFragment` — is working around the fact that Apollo was not designed for
+imperative batch fetching.
+
+`graphql-request` with a plain `async` pagination loop would be a third of the code with
+zero ceremony, and would make the intent of the script immediately obvious.
+
+**6. `readFragment` accesses the internal `__ref` cache key** *(Sonnet)*
+
+`edge.node.__ref` is not a public API — it is Apollo's internal cache identifier.
+It works today but can break silently across Apollo versions.  
+Fix: include fragment spreads directly in the paginated query and read from `fetchMore`
+results, eliminating the need for post-hoc `readFragment` calls.
+
+**7. `gqlUserInfo` is mostly dead code ✦**
+
+It fetches ~15 fields — `followers`, `following`, `repositoryDiscussions`,
+`issueComments`, `publicKeys`, `contributionYears`, etc. — none of which are exported or
+used in the template. Only `viewer.login` (used to filter own PRs) is actually consumed.  
+Fix: replace with `{ viewer { id login } }`, or fold `login` into one of the paginated queries.
+
+---
+
+### Error handling
+
+**8. Missing `USER_TOKEN` sends `Authorization: Bearer undefined` to GitHub** *(Sonnet)*
+
+There is no guard at startup. The failure eventually arrives as a confusing Apollo error deep
+in the pagination loop.  
+Fix: add at the top of `data.js`:
+
+```js
+if (!process.env.USER_TOKEN) {
+   throw new Error('USER_TOKEN environment variable is not set — copy .env.example to .env')
+}
+```
+
+**9. No error handling in the pagination loop ✦**
+
+A network error, a GitHub 429 (rate limit), or an invalid token mid-pagination throws an
+unhandled rejection with an Apollo stack trace. The script exits with no actionable message.  
+Fix: wrap each `fetchAll()` call in `try/catch` with a message identifying which entity was
+being fetched.
+
+---
+
+### Performance
+
+**10. Three independent fetches run sequentially** *(Sonnet)*
+
+Gists, repositories, and pull requests have no mutual dependencies but are awaited serially.  
+Fix:
+
+```js
+await Promise.all([
+   new RelayStylePaginationFetcher(gistQuery, ...).fetchAll(),
+   new RelayStylePaginationFetcher(repositoryQuery, ...).fetchAll(),
+   new RelayStylePaginationFetcher(pullRequestQuery, ...).fetchAll(),
+])
+```
+
+This could cut wall-clock time by up to 2/3 for large accounts.
+
+---
+
+## Summary
+
+| # | Area | Finding | Severity |
+|---|------|---------|----------|
+| 1 | README | No current focus or professional context | 💡 Suggestion |
+| 2 | README | iOS/Swift gists partially duplicated | 💡 Suggestion |
+| 3 | Technical | `fetchAll()` double-fetches page 1 (`cursor: null` start) | 🔴 Bug |
+| 4 | Technical | `prCount` can drift from `prs.length`; sort silently breaks | 🟡 Non-blocking |
+| 5 | Technical | Apollo Client is overkill for a one-shot CLI script | 🟡 Non-blocking |
+| 6 | Technical | `readFragment` relies on internal `__ref` cache key | 🟡 Non-blocking |
+| 7 | Technical | `gqlUserInfo` fetches ~15 fields; only `login` is ever used | 🟡 Non-blocking |
+| 8 | Technical | No guard for missing `USER_TOKEN` | 🟡 Non-blocking |
+| 9 | Technical | No error handling around pagination loop | 🟡 Non-blocking |
+| 10 | Technical | Three fetches run serially; could be `Promise.all`'d | 💡 Suggestion |
+

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -51,6 +51,7 @@ export const gqlPullRequestFragment = gql`
       id
       url
       number
+      title
       state
       repository {
          id


### PR DESCRIPTION
## Summary

Applies the fixes identified in the dual-model (Sonnet 4.6 + GPT-5.4) README review. `REVIEW.md` is included with only the remaining open findings.

## Changes

### Bug fixes
- **Broken Contributions links** — `href="{{url}}"` → `href="{{repo.url}}"` (every link in the table was `href=""`)
- **Empty PR tooltips** — added `title` to `gqlPullRequestFragment` so the `title="{{title}}"` attribute in the template is actually populated

### GitHub descriptions updated
- **`wiktionary-to-kindle`** — removed the self-defeating "making it useless" phrasing
- **`jmxsh`** — removed "hopefully"; new description is confident and descriptive

### README improvements
- Added a one-line intro below the `Hi there 👋` heading
- Renamed *Top projects* → *Featured projects*
- Most Starred tables now show **name first**, then description
- *Code examples* and *Misc* sections collapsed into a `<details>` block (*Experiments & more*)

### REVIEW.md
- Removed the 8 resolved findings; remaining 10 open issues preserved and renumbered
