### PR TITLE
Stop fetching unused gist fork/comment nodes

### DIFF
--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -11,20 +11,8 @@ export const gqlGistFragment = gql`
       stargazerCount
       createdAt
       updatedAt
-      forks(first: 1, orderBy: { direction: DESC, field: CREATED_AT }) {
-         totalCount
-         nodes {
-            createdAt
-            owner { login }
-         }
-      }
-      comments(last: 1) {
-         totalCount
-         nodes {
-            createdAt
-            author { login }
-         }
-      }
+      forks { totalCount }
+      comments { totalCount }
       files {
          name
       }


### PR DESCRIPTION
## Why

The `generate-readme` workflow has been failing since 2026-08-01 ([run 30678284560](https://github.com/nyg/nyg/actions/runs/30678284560), [run 30692648944](https://github.com/nyg/nyg/actions/runs/30692648944)). `pnpm generate` crashes on an unhandled GraphQL error:

```
CombinedGraphQLErrors: Something went wrong while executing your query
```

That generic message is a server-side 500 from GitHub's GraphQL API, reproducible on demand (3/3 attempts).

## Root cause

The gist fragment requested `forks(first: 1, orderBy: { direction: DESC, field: CREATED_AT })` with a `nodes` selection. One gist is the trigger:

| Gist | GraphQL `forks.totalCount` | REST forks |
|---|---|---|
| `c90f36abbd30f72c8b6681ef23db886b` | 3 | 3 ✅ |
| `b8cd742250826cb1471f` | 13 | 13 ✅ |
| [`b6a80bf79e72599230c312c69e963e60`](https://gist.github.com/nyg/b6a80bf79e72599230c312c69e963e60) | 10 | **8** ❌ |

Two fork records remain in GitHub's index while the underlying gists are no longer visible — deleted, made secret, or the owner suspended. GraphQL counts them, then 500s trying to enumerate them. Ordering `CREATED_AT DESC` landed on one immediately.

## Why not handle it more gracefully

Both obvious approaches are ruled out by how the API behaves:

- **The bad records can't be skipped.** They fail even with no field selected — `forks(first: 9) { edges { cursor } }` still 500s. A failed page returns no `endCursor`, so the connection is dead from that element onward.
- **There's no partial data to keep.** GitHub returns HTTP 200 with an `errors` array and *no* `data` key. Tested against the live query: `errorPolicy: 'none'` throws, `'all'` gives `data: undefined`, `'ignore'` gives `data: undefined` and hides the error. None salvage a partial result.

A two-pass approach (enumerate safely for cursors, then fetch per gist and skip failures) does work — verified at 21 ok / 1 unreadable — but costs ~22 requests per run instead of 1, so it wasn't worth it here.

## What changed

The `nodes` selections were dead weight — [`README.template.md`](https://github.com/nyg/nyg/blob/master/README.template.md) reads only `forks.totalCount` and `comments.totalCount`, and `gistHelper` touches neither. Dropping them fixes the failure and removes an unused sub-request:

```graphql
forks { totalCount }
comments { totalCount }
```

## Verification

- `pnpm generate` exits 0 against the live API
- `pnpm lint` clean
- Gist table renders unchanged (`iOSCreatePDF.swift`: 13 forks, 30 comments)
- Only README diff was the pending `wiktionary-to-kindle` move from #65 that the failed job never published

## Note for the reviewer

`README.md` is deliberately not included — the workflow commits it separately ("Update README.md and cards"), and it will regenerate on merge, publishing the #65 change that has been stuck.

This is the minimal fix, so a future poisoned record in a *different* field would fail the job the same way. With `nodes` gone the remaining gist fields are all scalars and `totalCount`, which is the shape that didn't break — but the per-gist fallback above is the escape hatch if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)